### PR TITLE
Add basic end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,7 @@ jobs:
         run: ./bin/setup
       - name: Install the package
         run: "micropython -m mip install github:${{ github.repository }}@${{ github.ref_name }}"
-      - name: Run tests
+      - name: Run unit tests
         run: micropython -m unittest
+      - name: Run end-to-end tests
+        run: ./bin/test_e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     env:
-      MICROPYPATH: ".frozen:~/.micropython/lib:/usr/lib/micropython:$(pwd)"
+      MICROPYPATH: "$(pwd)/tests/mocks:$(pwd):.frozen:~/.micropython/lib:/usr/lib/micropython"
     steps:
       - uses: actions/checkout@v2
       - name: Build micropython

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         run: ./bin/setup
       - name: Install the package dependencies
         run: "micropython -m mip install github:${{ github.repository }}@${{ github.ref_name }}"
-      - name: Install mosquitto
-        run: sudo apt-get install -y mosquitto
       - name: Run unit tests
         run: micropython -m unittest
+      - name: Install mosquitto
+        run: sudo apt-get install -y mosquitto
       - name: Run end-to-end tests
         run: ./bin/test_e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
           rm -rf micropython
       - name: Install test dependencies
         run: ./bin/setup
-      - name: Install the package
+      - name: Install the package dependencies
         run: "micropython -m mip install github:${{ github.repository }}@${{ github.ref_name }}"
+      - name: Install mosquitto
+        run: sudo apt-get install -y mosquitto
       - name: Run unit tests
         run: micropython -m unittest
       - name: Run end-to-end tests

--- a/README.md
+++ b/README.md
@@ -29,28 +29,62 @@ TODO
 
 You need python and a build of micropython with `asyncio` support. Follow the steps in the CI workflow to get a `micropython` binary and add it to your `PATH`.
 
-Before making changes, install the development dependencies:
+Before making changes, install the development (CPython) dependencies:
 
 ```bash
 pip install -r dev-requirements.txt
 ```
 
-After making changes, you can run the linter:
+### Linting
+
+This project uses [ruff](https://github.com/astral-sh/ruff) for linting. After making changes, you can run the linter:
 
 ```bash
 ruff check
 ```
 
-Before running tests, install the test dependencies:
+### Testing
+
+Before running tests, install the test (micropython) dependencies:
 
 ```bash
 ./bin/setup
 ```
 
-Then, you can run the tests using the micropython version of `unittest`:
+Note that you need to set up your `MICROPYPATH` environment variable so that the local copy of the package is loaded before any installed packages.
+
+```bash
+export MICROPYPATH="$(pwd)/tests/mocks:$(pwd):.frozen:~/.micropython/lib:/usr/lib/micropython"
+```
+
+#### Unit tests
+
+You can run the unit tests using the micropython version of `unittest`:
 
 ```bash
 micropython -m unittest
+```
+
+#### Integration tests
+
+Integration tests use a running MQTT broker ([mosquitto](https://mosquitto.org/)), which you need to have installed (e.g. with `brew`).
+
+There is a script that will set up the test environment, run the tests, and tear down the broker afterward:
+
+```bash
+./bin/test_e2e
+```
+
+Sometimes it's useful to debug an individual integration test. To do this, you need to run the broker yourself, then set up the environment and invoke the test directly:
+
+```bash
+mosquitto -v  # keep open to check the broker logs
+```
+
+Then in another terminal:
+
+```bash
+LOG_LEVEL=DEBUG MICROPYPATH="$(pwd)/tests/mocks:$(pwd):.frozen:~/.micropython/lib:/usr/lib/micropython" micropython ./tests/e2e/e2e_pubsub.py
 ```
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An async MQTTv5 client for micropython on ESP32 and unix.
 
-Adapted from [micropython-mqtt](https://github.com/peterhinch/micropython-mqtt/tree/master).
+Adapted from [mqtt_as](https://github.com/zcattacz/mqtt_as) and [micropython-mqtt](https://github.com/peterhinch/micropython-mqtt/tree/master).
 
 ## Installation
 

--- a/amqc/client.py
+++ b/amqc/client.py
@@ -143,7 +143,10 @@ class MQTT_base:
 
     def _set_disconnect(self, rc):
         if self._has_connected:
-            self._logger.warning(f"Disconnected with code: {rc}")
+            if rc == "disc":
+                self._logger.info("Disconnected from broker")
+            else:
+                self._logger.warning(f"Disconnected from broker with code: {rc}")
             self._has_connected = False
             self.down.set()
 
@@ -410,7 +413,7 @@ class MQTT_base:
             self._logger.debug("CONNACK properties: %s", decoded_props)
             self.topic_alias_maximum = decoded_props.get(0x22, 0)
 
-        self._logger.info("connected to broker.")  # Got CONNACK
+        self._logger.info("Connected to broker")  # Got CONNACK
         self._in_connect = False
         self._has_connected = True
         asyncio.create_task(self._handle_msg())  # Task quits on connection fail.

--- a/amqc/properties.py
+++ b/amqc/properties.py
@@ -5,6 +5,44 @@ https://github.com/peterhinch/micropython-mqtt/blob/master/mqtt_as/mqtt_v5_prope
 
 import struct
 
+# Properties available in MQTTv5; see:
+# https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901027
+PAYLOAD_FORMAT_INDICATOR = 0x01
+MESSAGE_EXPIRY_INTERVAL = 0x02
+CONTENT_TYPE = 0x03
+RESPONSE_TOPIC = 0x08
+CORRELATION_DATA = 0x09
+SUBSCRIPTION_IDENTIFIER = 0x0B
+SESSION_EXPIRY_INTERVAL = 0x11
+ASSIGNED_CLIENT_IDENTIFIER = 0x12
+SERVER_KEEP_ALIVE = 0x13
+AUTHENTICATION_METHOD = 0x15
+AUTHENTICATION_DATA = 0x16
+REQUEST_PROBLEM_INFORMATION = 0x17
+WILL_DELAY_INTERVAL = 0x18
+REQUEST_RESPONSE_INFORMATION = 0x19
+RESPONSE_INFORMATION = 0x1A
+SERVER_REFERENCE = 0x1C
+REASON_STRING = 0x1F
+RECEIVE_MAXIMUM = 0x21
+TOPIC_ALIAS_MAXIMUM = 0x22
+TOPIC_ALIAS = 0x23
+MAXIMUM_QOS = 0x24
+RETAIN_AVAILABLE = 0x25
+USER_PROPERTY = 0x26
+MAXIMUM_PACKET_SIZE = 0x27
+WILDCARD_SUBSCRIPTION_AVAILABLE = 0x28
+SUBSCRIPTION_IDENTIFIERS_AVAILABLE = 0x29
+SHARED_SUBSCRIPTION_AVAILABLE = 0x2A
+
+# Indicates payload is UTF-8 encoded; pair with CONTENT_TYPE as a MIME type:
+# 
+# {
+#     PAYLOAD_FORMAT_INDICATOR: PAYLOAD_FORMAT_UTF8,
+#     CONTENT_TYPE: "application/json",
+# }
+PAYLOAD_FORMAT_UTF8 = bytes([1])    # 0x01
+
 
 def encode_byte(value):
     # It takes in a byte and returns a byte
@@ -51,25 +89,25 @@ def encode_variable_byte_int(value):
 # This table does not contain all properties (unlike the decode table)
 # as not all properties can be sent by the client.
 ENCODE_TABLE = {
-    0x01: encode_byte,  # Payload Format Indicator
-    0x02: encode_four_byte_int,  # Message Expiry Interval
-    0x03: encode_string,  # Content Type
-    0x08: encode_string,  # Response Topic
-    0x09: encode_binary,  # Correlation Data
-    0x0B: encode_variable_byte_int,  # Subscription Identifier
-    0x11: encode_four_byte_int,  # Session Expiry Interval
-    0x15: encode_string,  # Authentication Method
-    0x16: encode_binary,  # Authentication Data
-    0x17: encode_byte,  # Request Problem Information
-    0x18: encode_four_byte_int,  # Will Delay Interval
-    0x19: encode_byte,  # Request Response Information
-    0x1C: encode_string,  # Server Reference
-    0x1F: encode_string,  # Reason String
-    0x21: encode_two_byte_int,  # Receive Maximum
-    0x22: encode_two_byte_int,  # Topic Alias Maximum
-    0x23: encode_two_byte_int,  # Topic Alias
-    0x26: encode_string_pair,  # User Property
-    0x27: encode_four_byte_int,  # Maximum Packet Size
+    PAYLOAD_FORMAT_INDICATOR: encode_byte,
+    MESSAGE_EXPIRY_INTERVAL: encode_four_byte_int,
+    CONTENT_TYPE: encode_string,
+    RESPONSE_TOPIC: encode_string,
+    CORRELATION_DATA: encode_binary,
+    SUBSCRIPTION_IDENTIFIER: encode_variable_byte_int,
+    SESSION_EXPIRY_INTERVAL: encode_four_byte_int,
+    AUTHENTICATION_METHOD: encode_string,
+    AUTHENTICATION_DATA: encode_binary,
+    REQUEST_PROBLEM_INFORMATION: encode_byte,
+    WILL_DELAY_INTERVAL: encode_four_byte_int,
+    REQUEST_RESPONSE_INFORMATION: encode_byte,
+    SERVER_REFERENCE: encode_string,
+    REASON_STRING: encode_string,
+    RECEIVE_MAXIMUM: encode_two_byte_int,
+    TOPIC_ALIAS_MAXIMUM: encode_two_byte_int,
+    TOPIC_ALIAS: encode_two_byte_int,
+    USER_PROPERTY: encode_string_pair,
+    MAXIMUM_PACKET_SIZE: encode_four_byte_int,
 }
 
 
@@ -186,33 +224,33 @@ def decode_variable_byte_int(props, offset):
 
 
 decode_property_lookup = {
-    0x01: decode_byte,  # Payload Format Indicator
-    0x02: decode_four_byte_int,  # Message Expiry Interval
-    0x03: decode_string,  # Content Type
-    0x08: decode_string,  # Response Topic
-    0x09: decode_binary,  # Correlation Data
-    0x0B: decode_variable_byte_int,  # Subscription Identifier
-    0x11: decode_four_byte_int,  # Session Expiry Interval
-    0x12: decode_string,  # Assigned Client Identifier
-    0x13: decode_two_byte_int,  # Server Keep Alive
-    0x15: decode_string,  # Authentication Method
-    0x16: decode_binary,  # Authentication Data
-    0x17: decode_byte,  # Request Problem Information
-    0x18: decode_four_byte_int,  # Will Delay Interval
-    0x19: decode_byte,  # Request Response Information
-    0x1A: decode_string,  # Response Information
-    0x1C: decode_string,  # Server Reference
-    0x1F: decode_string,  # Reason String
-    0x21: decode_two_byte_int,  # Receive Maximum
-    0x22: decode_two_byte_int,  # Topic Alias Maximum
-    0x23: decode_two_byte_int,  # Topic Alias
-    0x24: decode_byte,  # Maximum QoS
-    0x25: decode_byte,  # Retain Available
-    0x26: decode_string_pair,  # User Property
-    0x27: decode_four_byte_int,  # Maximum Packet Size
-    0x28: decode_byte,  # Wildcard Subscription Available
-    0x29: decode_byte,  # Subscription Identifiers Available
-    0x2A: decode_byte,  # Shared Subscription Available
+    PAYLOAD_FORMAT_INDICATOR: decode_byte,
+    MESSAGE_EXPIRY_INTERVAL: decode_four_byte_int,
+    CONTENT_TYPE: decode_string,
+    RESPONSE_TOPIC: decode_string,
+    CORRELATION_DATA: decode_binary,
+    SUBSCRIPTION_IDENTIFIER: decode_variable_byte_int,
+    SESSION_EXPIRY_INTERVAL: decode_four_byte_int,
+    ASSIGNED_CLIENT_IDENTIFIER: decode_string,
+    SERVER_KEEP_ALIVE: decode_two_byte_int,
+    AUTHENTICATION_METHOD: decode_string,
+    AUTHENTICATION_DATA: decode_binary,
+    REQUEST_PROBLEM_INFORMATION: decode_byte,
+    WILL_DELAY_INTERVAL: decode_four_byte_int,
+    REQUEST_RESPONSE_INFORMATION: decode_byte,
+    RESPONSE_INFORMATION: decode_string,
+    SERVER_REFERENCE: decode_string,
+    REASON_STRING: decode_string,
+    RECEIVE_MAXIMUM: decode_two_byte_int,
+    TOPIC_ALIAS_MAXIMUM: decode_two_byte_int,
+    TOPIC_ALIAS: decode_two_byte_int,
+    MAXIMUM_QOS: decode_byte,
+    RETAIN_AVAILABLE: decode_byte,
+    USER_PROPERTY: decode_string_pair,
+    MAXIMUM_PACKET_SIZE: decode_four_byte_int,
+    WILDCARD_SUBSCRIPTION_AVAILABLE: decode_byte,
+    SUBSCRIPTION_IDENTIFIERS_AVAILABLE: decode_byte,
+    SHARED_SUBSCRIPTION_AVAILABLE: decode_byte,
 }
 
 

--- a/bin/test_e2e
+++ b/bin/test_e2e
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# ensure we can import the modules in src/ and src/lib/
-# import mocked modules from tests/mocks/ first so they take precedence
-export MICROPYPATH=".frozen:~/.micropython/lib:/usr/lib/micropython:$(pwd)/tests/mocks:$(pwd)"
+# ensure we can import the modules from the package
+# import any mocked modules from tests/mocks/ first so they take precedence
+export MICROPYPATH="$(pwd)/tests/mocks:$(pwd):.frozen:~/.micropython/lib:/usr/lib/micropython"
 
 # bail out if mosquitto executable not found with `which mosquitto`
 if ! which mosquitto > /dev/null; then

--- a/bin/test_e2e
+++ b/bin/test_e2e
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# ensure we can import the modules in src/ and src/lib/
+# import mocked modules from tests/mocks/ first so they take precedence
+export MICROPYPATH=".frozen:~/.micropython/lib:/usr/lib/micropython:$(pwd)/tests/mocks:$(pwd)"
+
+# bail out if mosquitto executable not found with `which mosquitto`
+if ! which mosquitto > /dev/null; then
+    echo "mosquitto not found"
+    exit 1
+fi
+
+# start mosquitto broker
+echo "starting mosquitto broker"
+mosquitto -d
+
+# loop over all test files in tests/mpy/e2e and run them with ./bin/micropython
+for test in tests/e2e/e2e_*.py; do
+    # print test file name
+    echo -en "$test "
+
+    # run test and if any test fails, set failed=1
+    if ! micropython $test; then
+        failed=1
+    fi
+done
+
+# stop mosquitto broker
+echo "shutting down mosquitto broker"
+pkill mosquitto
+
+# if failed is set, exit with status 1 (so CI will fail)
+if [ -n "$failed" ]; then
+    exit 1
+fi

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 unittest
 unittest-discover
+time

--- a/tests/e2e/e2e_keepalive.py
+++ b/tests/e2e/e2e_keepalive.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env micropython
+
+"""End-to-end test for keepalive and client disconnection functionality."""
+
+import asyncio
+import logging
+import os
+import sys
+
+from amqc.client import MQTTClient, config
+
+# Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
+logger = logging.getLogger()
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "WARNING").upper()))
+formatter = logging.Formatter(
+    "%(asctime)s.%(msecs)d - %(levelname)s - %(name)s - %(message)s"
+)
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(formatter)
+logger.handlers = []
+logger.addHandler(handler)
+device_logger = logging.getLogger("device")
+control_logger = logging.getLogger("control")
+
+# Base config
+config["server"] = "localhost"
+config["queue_len"] = 1
+
+# Device client config
+device_config = config.copy()
+device_config["client_id"] = "device"
+device_config["keepalive"] = 2  # Set very short keepalive interval
+device_config["will"] = (  # Will message on disconnect
+    "test/topic",
+    b"Last will message",
+)
+
+# Control client config
+control_config = config.copy()
+control_config["client_id"] = "control"
+last_will_sent = asyncio.Event()
+
+# Create the clients
+device_client = MQTTClient(device_config, logger=device_logger)
+control_client = MQTTClient(control_config, logger=control_logger)
+
+# Force the device client to ping slower than the keepalive interval, so
+# the broker will disconnect it
+device_client._ping_interval = 20000
+
+
+# Handler to check last will message
+async def message_handler():
+    async for topic, payload, _retained, _properties in control_client.queue:
+        logger.debug(f"Received message on {topic.decode()}: {payload.decode()}")
+        if topic.decode() == "test/topic" and payload.decode() == "Last will message":
+            last_will_sent.set()
+
+
+async def main():
+    # Connect both clients
+    await device_client.connect()
+    await control_client.connect()
+
+    # Subscribe to the last will topic and system topic
+    await control_client.subscribe("test/topic")
+    asyncio.create_task(message_handler())
+
+    # Wait to receive the last will message
+    await asyncio.wait_for(last_will_sent.wait(), timeout=30)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+    print("\033[1m\tOK\033[0m")

--- a/tests/e2e/e2e_properties.py
+++ b/tests/e2e/e2e_properties.py
@@ -19,7 +19,7 @@ from amqc.properties import (
 
 # Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
 logger = logging.getLogger()
-logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "ERROR").upper()))
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "WARNING").upper()))
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(formatter)

--- a/tests/e2e/e2e_properties.py
+++ b/tests/e2e/e2e_properties.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env micropython
+
+"""End-to-end test for publish/subscribe functionality."""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from amqc.client import MQTTClient, config
+from amqc.properties import (
+    CONTENT_TYPE,
+    CORRELATION_DATA,
+    PAYLOAD_FORMAT_INDICATOR,
+    PAYLOAD_FORMAT_UTF8,
+    USER_PROPERTY,
+)
+
+# Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
+logger = logging.getLogger()
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "ERROR").upper()))
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(formatter)
+logger.handlers = []
+logger.addHandler(handler)
+rx_logger = logging.getLogger("rx")
+tx_logger = logging.getLogger("tx")
+
+# MQTT Client config
+config["server"] = "localhost"
+config["queue_len"] = 1  # use event queue
+tx_config = config.copy()
+rx_config = config.copy()
+tx_config["client_id"] = "tx"
+rx_config["client_id"] = "rx"
+
+# Set up MQTT clients
+tx_client = MQTTClient(tx_config, logger=tx_logger)
+rx_client = MQTTClient(rx_config, logger=rx_logger)
+
+# Store received messages
+messages_received = []
+
+
+# Handler for received messages that logs and stores them
+async def message_handler():
+    async for topic, payload, _retained, properties in rx_client.queue:
+        logger.debug(
+            f"Received message '{payload.decode()}' on {topic.decode()} with properties {properties}"
+        )
+        messages_received.append((payload, properties))
+
+
+# Simulate publishing messages with various MQTTv5 properties
+async def publisher():
+    # Send a message with binary correlation data
+    await tx_client.publish(
+        "test/topic",
+        "Correlation data test".encode(),
+        properties={CORRELATION_DATA: "my opaque value".encode()},
+    )
+    await asyncio.sleep(0.1)
+
+    # Send a message with some arbitrary user properties
+    await tx_client.publish(
+        "test/topic",
+        "User properties test".encode(),
+        properties={
+            USER_PROPERTY: {
+                "key1": "value1",
+            }
+        },
+    )
+    await asyncio.sleep(0.1)
+
+    # Use payload format and content-type to send a UTF-8 JSON payload
+    await tx_client.publish(
+        "test/topic",
+        '{"key": "工"}'.encode("utf-8"),
+        properties={
+            PAYLOAD_FORMAT_INDICATOR: PAYLOAD_FORMAT_UTF8,
+            CONTENT_TYPE: "application/json",
+        },
+    )
+    await asyncio.sleep(0.1)
+
+
+# Main test function
+async def main():
+    # Connect the clients
+    await tx_client.connect(True)
+    await rx_client.connect(True)
+
+    # Subscribe and start the message handler
+    await rx_client.subscribe("test/topic")
+    asyncio.create_task(message_handler())
+
+    # Simulate publishing messages with various MQTTv5 properties
+    try:
+        await publisher()
+    # Handle any exceptions that occur during publishing
+    except Exception:
+        logger.exception("Error occurred while publishing messages", exc_info=True)
+    # Ensure we disconnect the clients
+    finally:
+        await tx_client.disconnect()
+        await rx_client.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+    # Ensure all messages were received
+    assert (
+        len(messages_received) == 3
+    ), f"Expected 3 messages, got {len(messages_received)}"
+
+    # Check the correlation data message
+    corr_msg = messages_received[0]
+    assert (
+        corr_msg[0] == b"Correlation data test"
+    ), f"Unexpected payload in correlation data message: {corr_msg[0].decode()}"
+    assert (
+        corr_msg[1][CORRELATION_DATA] == b"my opaque value"
+    ), f"Unexpected correlation data: {corr_msg[1][CORRELATION_DATA]}"
+
+    # Check the user properties message
+    user_prop_msg = messages_received[1]
+    assert (
+        user_prop_msg[0] == b"User properties test"
+    ), f"Unexpected payload in user properties message: {user_prop_msg[0].decode()}"
+    assert user_prop_msg[1][USER_PROPERTY] == {
+        "key1": "value1"
+    }, f"Unexpected user properties: {user_prop_msg[1][USER_PROPERTY]}"
+
+    # Check the UTF-8 JSON payload
+    utf8_json_msg = messages_received[2]
+    utf8_json_payload = utf8_json_msg[0].decode("utf-8")
+    assert (
+        utf8_json_payload == '{"key": "工"}'
+    ), f"Unexpected payload in UTF-8 JSON message: {utf8_json_payload}"
+    props = utf8_json_msg[1]
+    assert (
+        props[PAYLOAD_FORMAT_INDICATOR] == 1
+    ), f"Unexpected PAYLOAD_FORMAT_INDICATOR: {props[PAYLOAD_FORMAT_INDICATOR]}"
+    assert (
+        props[CONTENT_TYPE] == "application/json"
+    ), f"Unexpected CONTENT_TYPE: {props[CONTENT_TYPE]}"
+    parsed_obj = json.loads(utf8_json_payload)
+    assert parsed_obj == {"key": "工"}, f"Unexpected parsed JSON object: {parsed_obj}"
+
+    print("\033[1m\tOK\033[0m")

--- a/tests/e2e/e2e_properties.py
+++ b/tests/e2e/e2e_properties.py
@@ -90,8 +90,8 @@ async def publisher():
 # Main test function
 async def main():
     # Connect the clients
-    await tx_client.connect(True)
-    await rx_client.connect(True)
+    await tx_client.connect()
+    await rx_client.connect()
 
     # Subscribe and start the message handler
     await rx_client.subscribe("test/topic")

--- a/tests/e2e/e2e_properties.py
+++ b/tests/e2e/e2e_properties.py
@@ -20,7 +20,7 @@ from amqc.properties import (
 # Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
 logger = logging.getLogger()
 logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "WARNING").upper()))
-formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+formatter = logging.Formatter("%(asctime)s.%(msecs)d - %(levelname)s - %(name)s - %(message)s")
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(formatter)
 logger.handlers = []

--- a/tests/e2e/e2e_pubsub.py
+++ b/tests/e2e/e2e_pubsub.py
@@ -12,7 +12,7 @@ from amqc.client import config as mqtt_settings
 
 # Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
 logger = logging.getLogger()
-logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "ERROR").upper()))
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "WARNING").upper()))
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(formatter)

--- a/tests/e2e/e2e_pubsub.py
+++ b/tests/e2e/e2e_pubsub.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env micropython
+
+"""End-to-end test for publish/subscribe functionality."""
+
+import asyncio
+import logging
+import os
+import sys
+
+from amqc.client import MQTTClient
+from amqc.client import config as mqtt_settings
+
+# Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
+logger = logging.getLogger()
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "ERROR").upper()))
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(formatter)
+logger.handlers = []
+logger.addHandler(handler)
+
+# MQTT Client config
+mqtt_settings["server"] = "localhost"
+mqtt_settings["queue_len"] = 1  # use event queue
+device_mqtt_settings = mqtt_settings.copy()
+control_mqtt_settings = mqtt_settings.copy()
+device_mqtt_settings["client_id"] = "device"
+control_mqtt_settings["client_id"] = "server"
+
+# Set up MQTT clients
+device_client = MQTTClient(device_mqtt_settings)
+control_client = MQTTClient(control_mqtt_settings)
+
+# Store received messages
+device_received = []
+control_received = []
+
+
+# Handler for device messages that logs and stores them
+async def device_handler():
+    async for topic, payload, _retained, _properties in device_client.queue:
+        logger.debug(f"Device received {len(payload)} bytes on {topic.decode()}: {payload.decode()}")
+        device_received.append(payload)
+
+
+# Handler for control messages that logs and stores them
+async def control_handler():
+    async for topic, payload, _retained, _properties in control_client.queue:
+        logger.debug(f"Control received {len(payload)} bytes on {topic.decode()}: {payload.decode()}")
+        control_received.append(payload)
+
+
+# Simulate publishing messages from device
+async def device_publisher():
+    for i in range(3):
+        await device_client.publish("/control", f"Device message {i}".encode())
+        logger.debug(f"Device published message {i} to /control")
+        await asyncio.sleep(0.1)  # Simulate some delay between messages
+
+
+# Simulate publishing messages from control
+async def control_publisher():
+    for i in range(3):
+        await control_client.publish("/device", f"Control message {i}".encode())
+        logger.debug(f"Control published message {i} to /device")
+        await asyncio.sleep(0.1)  # Simulate some delay between messages
+
+
+# Main test function
+async def main():
+    # Connect both clients
+    await device_client.connect(True)
+    logger.debug("Device client connected")
+    await control_client.connect(True)
+    logger.debug("Control client connected")
+
+    # Subscribe to topics
+    await device_client.subscribe("/device")
+    logger.debug("Device client subscribed to /device")
+    await control_client.subscribe("/control")
+    logger.debug("Control client subscribed to /control")
+
+    # Run handlers in the background
+    asyncio.create_task(device_handler())
+    asyncio.create_task(control_handler())
+
+    # Run publishers in the foreground
+    await device_publisher()
+    await control_publisher()
+
+    # Disconnect and clean up
+    await device_client.disconnect()
+    logger.debug("Device client disconnected")
+    await control_client.disconnect()
+    logger.debug("Control client disconnected")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+    # Ensure all messages were received
+    assert (
+        len(device_received) == 3
+    ), f"Device received {len(device_received)} messages, expected 3"
+    assert (
+        len(control_received) == 3
+    ), f"Control received {len(control_received)} messages, expected 3"
+    for i in range(3):
+        assert (
+            device_received[i] == f"Control message {i}".encode()
+        ), f"Expected Control message {i}, got {device_received[i]}"
+        assert (
+            control_received[i] == f"Device message {i}".encode()
+        ), f"Expected Device message {i}, got {control_received[i]}"
+
+    print("\033[1m\tOK\033[0m")

--- a/tests/e2e/e2e_pubsub.py
+++ b/tests/e2e/e2e_pubsub.py
@@ -69,9 +69,9 @@ async def control_publisher():
 # Main test function
 async def main():
     # Connect both clients
-    await device_client.connect(True)
+    await device_client.connect()
     logger.debug("Device client connected")
-    await control_client.connect(True)
+    await control_client.connect()
     logger.debug("Control client connected")
 
     # Subscribe to topics

--- a/tests/e2e/e2e_pubsub.py
+++ b/tests/e2e/e2e_pubsub.py
@@ -13,7 +13,7 @@ from amqc.client import config as mqtt_settings
 # Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
 logger = logging.getLogger()
 logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "WARNING").upper()))
-formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+formatter = logging.Formatter("%(asctime)s.%(msecs)d - %(levelname)s - %(name)s - %(message)s")
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(formatter)
 logger.handlers = []


### PR DESCRIPTION
Closes #4

- **Make logging more consistent**
- **Add mqtt_as ref to README**
- **Add e2e tests to build and basic pub/sub e2e test**
- **Ensure the local version of the package takes import precedence**
- **Add an e2e test for mqttv5 properties**
- **Log expected disconnects at INFO instead of WARNING**
- **Set default log level during e2e to WARNING**
- **Add info about e2e testing to the README**
- **Install mosquitto in CI**
- **Clean session is already the default**
- **Add millisecond values to logging formatter**
- **Update client logging slightly**
- **Add keepalive/last will test**
